### PR TITLE
Fix the application source

### DIFF
--- a/tanka/environments/default/argo-cd.jsonnet
+++ b/tanka/environments/default/argo-cd.jsonnet
@@ -13,15 +13,15 @@
         namespace: 'default',
       },
       spec: {
-        chart: 'argo-cd',
-        repoURL: 'https://argoproj.github.io/argo-helm',
-        targetRevision: '5.20.0',
         project: 'default',
         destination: {
           namespace: 'default',
           server: 'https://kubernetes.default.svc',
         },
         source: {
+          chart: 'argo-cd',
+          repoURL: 'https://argoproj.github.io/argo-helm',
+          targetRevision: '5.20.0',
           helm: {
             releaseName: 'argo-cd',
             values: |||


### PR DESCRIPTION
In order for the argo application to conform to the spec as defined by the CRD, the chart, repoURL and targetRevision must be a child of source.